### PR TITLE
Fix CI failures related to `publish-unit-test-result-action`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,12 @@ on:
       - "stack*.yaml"
   pull_request:
 
+permissions:
+  checks: write
+  contents: read
+  issues: read
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This is an attempt to fix the CI failures by adding explicit permissions to the workflow. Not sure if that's really the cause, but it seems to work at least.